### PR TITLE
Enable testing via CMake/llvm-lit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,19 @@
 cmake_minimum_required(VERSION 2.8)
 
+# FIXME: It may be removed when we use 2.8.12.
+if(CMAKE_VERSION VERSION_LESS 2.8.12)
+  # Invalidate a couple of keywords.
+  set(cmake_2_8_12_INTERFACE)
+  set(cmake_2_8_12_PRIVATE)
+else()
+  # Use ${cmake_2_8_12_KEYWORD} intead of KEYWORD in target_link_libraries().
+  set(cmake_2_8_12_INTERFACE INTERFACE)
+  set(cmake_2_8_12_PRIVATE PRIVATE)
+  if(POLICY CMP0022)
+    cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
+  endif()
+endif()
+
 # If we are not building as a part of LLVM, build Flang as an
 # standalone project, using LLVM as an external library:
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
@@ -297,7 +311,6 @@ macro(add_flang_library name)
 
   llvm_config( ${name} ${LLVM_LINK_COMPONENTS} )
   target_link_libraries( ${name} ${LLVM_COMMON_LIBS} )
-  link_system_libs( ${name} )
 
   install(TARGETS ${name}
     LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
         add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/count utils/count)
         add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/not utils/not)
         set(LLVM_UTILS_PROVIDED ON)
-        set(CLANG_TEST_DEPS FileCheck count not)
+        set(FLANG_TEST_DEPS FileCheck count not)
       endif()
       set(UNITTEST_DIR ${LLVM_MAIN_SRC_DIR}/utils/unittest)
       if(EXISTS ${UNITTEST_DIR}/googletest/include/gtest/gtest.h
@@ -353,12 +353,14 @@ list(APPEND LLVM_COMMON_DEPENDS ${FLANG_TABLEGEN_TARGETS})
 
 add_subdirectory(lib)
 add_subdirectory(tools)
-add_subdirectory(test)
 
 if( LLVM_INCLUDE_TESTS )
-  # if( NOT FLANG_BUILT_STANDALONE )
-    add_subdirectory(unittests)
-  #endif()
+  add_subdirectory(unittests)
+  list(APPEND FLANG_TEST_DEPS FlangUnitTests)
+    list(APPEND FLANG_TEST_PARAMS
+      flang_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/test/Unit/lit.site.cfg
+      )
+  add_subdirectory(test)
 endif()
 
 # Workaround for MSVS10 to avoid the Dialog Hell

--- a/README.txt
+++ b/README.txt
@@ -40,6 +40,19 @@ compiler links to by default. This is built outside the LLVM tree.
 > cd build & make
 > cd build & make install
 
+Testing:
+
+> cmake -DLLVM_INCLUDE_TESTS=On ..
+> make check-flang
+
+If built within LLVM source tree, it should pick up test settings from it and
+running a separate make command should not be necessary. If you want to build
+tests in standalone flang build, make sure to add CMake flags that would
+install FileCheck with LLVM:
+
+> -DLLVM_INSTALL_UTILS=On -DLLVM_INCLUDE_TESTS=On
+
+
 //===----------------------------------------------------------------------===//
 // Using flang
 //===----------------------------------------------------------------------===//

--- a/include/flang/Sema/Scope.h
+++ b/include/flang/Sema/Scope.h
@@ -258,7 +258,7 @@ public:
 ///
 class EquivalenceScope {
 public:
-  struct InfluenceObject;
+  class InfluenceObject;
 
   class Object {
   public:

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -1,19 +1,19 @@
 set(LLVM_LINK_COMPONENTS support)
 
 add_flang_library(flangAST
-	ASTContext.cpp
-	Decl.cpp
-	DeclGroup.cpp
-	DeclarationName.cpp
-	Expr.cpp
+  ASTContext.cpp
+  Decl.cpp
+  DeclGroup.cpp
+  DeclarationName.cpp
+  Expr.cpp
   ExprConstant.cpp
   ExprArray.cpp
-	FormatSpec.cpp
+  FormatSpec.cpp
   FormatItem.cpp
   IOSpec.cpp
-	Stmt.cpp
+  Stmt.cpp
   ASTDumper.cpp
-	Type.cpp
+  Type.cpp
   IntrinsicFunctions.cpp
   )
 
@@ -25,5 +25,6 @@ add_dependencies(flangAST
   )
 
 target_link_libraries(flangAST
+  PRIVATE
   flangBasic
   )

--- a/lib/CodeGen/CGIOLibflang.cpp
+++ b/lib/CodeGen/CGIOLibflang.cpp
@@ -116,6 +116,9 @@ void CGLibflangWriteEmitter::EmitWriteUnformattedBuiltin(const BuiltinType *BTy,
     Func = CGM.GetRuntimeFunction2("write_logical", ControllerPtr->getType(),
                                    E->getType(), CGType(), getTransferABI());
     break;
+  default:
+    assert(false && "Invalid TypeSpec");
+    break;
   }
   CallArgList ArgList;
   CGF.EmitCallArg(ArgList, ControllerPtr, Func.getInfo()->getArguments()[0]);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LLVM_BINARY_DIR ${FLANG_PATH_TO_LLVM_BUILD})
 set(LLVM_TOOLS_DIR ${FLANG_PATH_TO_LLVM_BUILD}/tools)
 set(LLVM_LIBS_DIR ${FLANG_PATH_TO_LLVM_BUILD}/lib)
 
-configure_file(lit.site.cfg.in  ${CMAKE_SOURCE_DIR}/test/lit.site.cfg)
-configure_file(TestRunner.sh.in ${CMAKE_SOURCE_DIR}/test/TestRunner.sh)
+configure_file(lit.site.cfg.in  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg)
+configure_file(TestRunner.sh.in ${CMAKE_CURRENT_BINARY_DIR}/TestRunner.sh)
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,39 @@ set(LLVM_BINARY_DIR ${FLANG_PATH_TO_LLVM_BUILD})
 set(LLVM_TOOLS_DIR ${FLANG_PATH_TO_LLVM_BUILD}/tools)
 set(LLVM_LIBS_DIR ${FLANG_PATH_TO_LLVM_BUILD}/lib)
 
-configure_file(lit.site.cfg.in  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg)
+#configure_file(lit.site.cfg.in  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg)
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
+  )
+
 configure_file(TestRunner.sh.in ${CMAKE_CURRENT_BINARY_DIR}/TestRunner.sh)
 
+option(FLANG_TEST_USE_VG "Run Flang tests under Valgrind" OFF)
+if(FLANG_TEST_USE_VG)
+  set(FLANG_TEST_EXTRA_ARGS ${FLANG_TEST_EXTRA_ARGS} "--vg")
+endif ()
+
+list(APPEND FLANG_TEST_DEPS
+  flang
+  )
+
+set(FLANG_TEST_PARAMS
+  flang_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
+  )
+
+if( NOT FLANG_BUILT_STANDALONE )
+  list(APPEND FLANG_TEST_DEPS
+    llvm-config
+    FileCheck
+    )
+endif()
+
+add_lit_testsuite(check-flang "Running Flang regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  PARAMS ${FLANG_TEST_PARAMS}
+  DEPENDS ${FLANG_TEST_DEPS}
+  ARGS ${FLANG_TEST_EXTRA_ARGS}
+  )
+set_target_properties(check-flang PROPERTIES FOLDER "Flang tests")
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -3,6 +3,8 @@
 import os
 import platform
 
+import lit.formats
+
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
@@ -122,13 +124,13 @@ def inferFlang(PATH):
 
 # When running under valgrind, we mangle '-vg' onto the end of the triple so we
 # can check it with XFAIL and XTARGET.
-if lit.useValgrind:
+if lit_config.useValgrind:
     config.target_triple += '-vg'
 
 if not config.flang:
     config.flang = inferFlang(config.environment['PATH'])
-if not lit.quiet:
-    lit.note('using flang: %r' % config.flang)
+if not lit_config.quiet:
+    lit_config.note('using flang: %r' % config.flang)
 config.substitutions.append( ('%flang', ' ' + config.flang + ' ') )
 config.substitutions.append( ('%test_dir', config.test_dir) )
 config.substitutions.append( ('%file_check', config.file_check) )

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -10,8 +10,8 @@ config.target_triple = "@TARGET_TRIPLE@"
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.
 try:
-    config.llvm_tools_dir = config.llvm_tools_dir % lit.params
-    config.llvm_libs_dir = config.llvm_libs_dir % lit.params
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_libs_dir = config.llvm_libs_dir % lit_config.params
 except KeyError,e:
     key, = e.args
     lit.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
@@ -20,5 +20,5 @@ except KeyError,e:
 config.flang = "@FLANG_BINARY_DIR@/bin/flang"
 config.test_dir = "@FLANG_SOURCE_DIR@/test"
 config.file_check = "@LLVM_BINARY_DIR@/bin/FileCheck"
-lit.load_config(config, "@FLANG_SOURCE_DIR@/test/lit.cfg")
+lit_config.load_config(config, "@FLANG_SOURCE_DIR@/test/lit.cfg")
 

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -25,7 +25,8 @@ target_link_libraries(flang
 
 set_target_properties(flang PROPERTIES VERSION ${FLANG_EXECUTABLE_VERSION})
 
-add_dependencies(flang flang-headers)
+# TODO open issue
+#add_dependencies(flang flang-headers)
 
 if(UNIX)
   set(flang_binary "flang${CMAKE_EXECUTABLE_SUFFIX}")

--- a/tools/driver/Main.cpp
+++ b/tools/driver/Main.cpp
@@ -255,6 +255,9 @@ std::string GetOutputName(StringRef Filename,
   case Backend_EmitLL:
     llvm::sys::path::replace_extension(Path, ".ll");
     break;
+  default:
+    assert(false && "No output name for action");
+    break;
   }
   return std::string(Path.begin(), Path.size());
 }
@@ -267,8 +270,8 @@ static bool EmitFile(llvm::raw_pwrite_stream &Out,
   //write instructions to file
   if(Action == Backend_EmitObj || Action == Backend_EmitAssembly){
     llvm::Module &Mod = *Module;
-    llvm::TargetMachine &Target = *TM;
 #if 0
+    llvm::TargetMachine &Target = *TM;
     llvm::TargetMachine::CodeGenFileType FileType =
       Action == Backend_EmitObj ? llvm::TargetMachine::CGFT_ObjectFile :
                                   llvm::TargetMachine::CGFT_AssemblyFile;

--- a/tools/driver/Main.cpp
+++ b/tools/driver/Main.cpp
@@ -469,16 +469,15 @@ static bool ParseFile(const std::string &Filename,
       //delete MPM;
     }
 
-    if(Interpret) {
+    if (Interpret) {
       //const char *Env[] = { "", nullptr };
       //Execute(CG->ReleaseModule(), Env);
-    } else if(OutputFile == "-"){
-      // FIXME: outputting to stdout is broken 
-      //EmitFile(llvm::outs(), CG->GetModule(), TM, BA);
-      OutputFiles.push_back(GetOutputName("stdout",BA));
-      EmitOutputFile(OutputFiles.back(), CG->GetModule(), TM, BA);
-    }else {
-      OutputFiles.push_back(GetOutputName(Filename, BA));
+    } else {
+      if(OutputFile == "-"){
+        OutputFiles.push_back(OutputFile);
+      }else {
+        OutputFiles.push_back(GetOutputName(Filename, BA));
+      }
       EmitOutputFile(OutputFiles.back(), CG->GetModule(), TM, BA);
     }
     delete CG;

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_flang_executable(exprEvaluatorTest
+add_flang_unittest(exprEvaluatorTest
   ExprEvaluator.cpp
   )
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,1 +1,12 @@
+add_custom_target(FlangUnitTests)
+set_target_properties(FlangUnitTests PROPERTIES FOLDER "Flang tests")
+
+# add_flang_unittest(test_dirname file1.cpp file2.cpp)
+#
+# Will compile the list of files together and link against the flang
+# Produces a binary named 'basename(test_dirname)'.
+function(add_flang_unittest test_dirname)
+  add_unittest(FlangUnitTests ${test_dirname} ${ARGN})
+endfunction()
+
 add_subdirectory(AST)


### PR DESCRIPTION
I was able to get the tests that use llvm-lit to work under CMake (just like LLVM does). This set of changes enables tests and fixes warnings, but does not attempt to deal with test results.