### PR TITLE
More test fixes

### DIFF
--- a/lib/CodeGen/CGStmt.cpp
+++ b/lib/CodeGen/CGStmt.cpp
@@ -473,7 +473,8 @@ void CodeGenFunction::EmitSelectCaseStmt(const SelectCaseStmt *S) {
 }
 
 void CodeGenFunction::EmitStopStmt(const StopStmt *S) {
-  EmitRuntimeCall(CGM.GetRuntimeFunction("stop", ArrayRef<llvm::Type*>()));
+  auto Func = CGM.GetRuntimeFunction("stop", ArrayRef<CGType>());
+  EmitCall(Func, ArrayRef<RValueTy>());
 }
 
 void CodeGenFunction::EmitReturnStmt(const ReturnStmt *S) {

--- a/test/CodeGen/Intrinsics/bitops.f95
+++ b/test/CodeGen/Intrinsics/bitops.f95
@@ -32,7 +32,7 @@ PROGRAM bittest
   i = ishft(i, 4)  ! CHECK: shl i32 {{.*}}, 4
   i = ishft(i, -2) ! CHECK: lshr i32 {{.*}}, 2
   i = ishft(i, i/4) ! CHECK: icmp sge i32 {{.*}}, 0
-  continue          ! CHECK-NEXT: select i1
+  continue          ! CHECK: select i1
 
   i = ishft(3, 1) ! CHECK: store i32 6
   i = ishft(8, -1) ! CHECK: store i32 4


### PR DESCRIPTION
Fix bitops test, closes #7 

Variable shift generates both left and right shifts and then uses select IR instruction to chose between them. Test only tries to verify compare and select instructions but trips on three more instructions in between. Trying to verify those three instructions is redundant and somewhat fragile, so it is better to change CHECK-NEEXT directive to CHECK.


Change EmitRuntimeCall to EmitCall for STOP statement, closes #8 

EmitRuntimeCall does not produce arguments, which triggers a debug assert in LLVM when generating code for STOP statement.
