### PR TITLE
Fix type != array erorrs

### DIFF
--- a/lib/CodeGen/CGArray.cpp
+++ b/lib/CodeGen/CGArray.cpp
@@ -243,7 +243,7 @@ void ArrayValueExprEmitter::VisitVarExpr(const VarExpr *E) {
       Ptr = CGF.GetVarPtr(VD);
     else
       Ptr = Builder.CreateConstInBoundsGEP2_32(
-          CGF.GetVarPtr(VD)->getType()->getArrayElementType(),
+          CGF.GetVarPtr(VD)->getType()->getPointerElementType(),
           CGF.GetVarPtr(VD), 0, 0);
   }
   EmitSections();

--- a/lib/CodeGen/CGExprCharacter.cpp
+++ b/lib/CodeGen/CGExprCharacter.cpp
@@ -189,7 +189,7 @@ llvm::Value *CodeGenFunction::GetCharacterTypeLength(QualType T) {
 CharacterValueTy CodeGenFunction::GetCharacterValueFromPtr(llvm::Value *Ptr,
                                                            QualType StorageType) {
   return CharacterValueTy(Builder.CreateConstInBoundsGEP2_32(
-                      Ptr->getType()->getArrayElementType(),Ptr, 0, 0),
+                      Ptr->getType()->getPointerElementType(),Ptr, 0, 0),
                     GetCharacterTypeLength(StorageType));
 }
 


### PR DESCRIPTION
Arry expression emitted as pointer type need to be treated as pointer
later in code generation as well.